### PR TITLE
Fix Compare implementation too strict

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,15 +145,15 @@ where
     }
 }
 
-impl<T> Compare<T> for Spanned<T>
+impl<T, Comp> Compare<C> for Spanned<T>
 where
-    T: Compare<T>,
+    T: Compare<Comp>,
 {
-    fn compare(&self, t: T) -> nom::CompareResult {
+    fn compare(&self, t: Comp) -> nom::CompareResult {
         self.data.compare(t)
     }
 
-    fn compare_no_case(&self, t: T) -> nom::CompareResult {
+    fn compare_no_case(&self, t: Comp) -> nom::CompareResult {
         self.data.compare_no_case(t)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ where
     }
 }
 
-impl<T, Comp> Compare<C> for Spanned<T>
+impl<T, Comp> Compare<Comp> for Spanned<T>
 where
     T: Compare<Comp>,
 {


### PR DESCRIPTION
For `Spanned<&'a str>` to implement `Compare<&'static str>` `'a` is required to outlive `'static`, which is too strict.

Fixes #2.